### PR TITLE
2023年度卒業メンバー名の追記

### DIFF
--- a/member.html
+++ b/member.html
@@ -108,10 +108,9 @@
         <div class="member">
           <details>
             <summary><strong>2023年度卒業生</strong></summary>
-              <li>○○　○○</li>
-              <li>○○　○○</li>
-              <li>○○　○○</li>
-              <li>○○　○○</li>
+              <li>大友　一樹</li>
+              <li>大森　壮真？</li>
+              <li>戸田　栞太</li>
           </details>
           <details>
             <summary><strong>2022年度卒業生</strong></summary>


### PR DESCRIPTION
## 動作確認

- [ ] メンバーの一覧画面にて、以下のように2023年度卒の名前が追加されていること

![スクリーンショット 2023-11-14 21 24 33](https://github.com/namaridamaX/yamakawa-hp/assets/67196994/32832413-78fb-4f08-946b-193cc37b9f48)
